### PR TITLE
Feature - update tests from Jest to Mocha

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -53,6 +53,7 @@
     "@types/chai": "^4.3.5",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
+    "@types/mocha": "^10.0.1",
     "@types/multer": "^1.4.7",
     "@types/node": "^16.7.10",
     "@types/supertest": "^2.0.12",


### PR DESCRIPTION
---
name: Update tests from Jest to Mocha
about: This will update from Jest to Mocha
---

## Summary

This change is designed to update all the unit testing script for the REST package. The update will change the scripts and make them use the usual two NPMs **Mocha** plus **Chai** instead of ~~Jest~~

## Motivation

This is because of the wide-spread use of **Mocha** alongside **Chai**

## Describe alternatives you've considered

N/A

## Additional context

Installed the previous mentioned NPMs with:

```sh
yarn workspace @aries-framework/rest add --dev mocha
yarn workspace @aries-framework/rest add --dev @types/mocha
yarn workspace @aries-framework/rest add --dev chai
yarn workspace @aries-framework/rest add --dev @types/chai
```

This is a just a Draft!
