### PR TITLE
reorganize docker layers for faster builds during development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ WORKDIR /app
 
 COPY package.json ./package.json
 COPY package-lock.json ./package-lock.json
+RUN npm ci && npm cache clean --force
+
 COPY tsoa.json ./tsoa.json
 COPY tsconfig.build.json ./tsconfig.build.json
 COPY bin ./bin
 COPY src ./src
-
-RUN npm ci && npm cache clean --force
 RUN npm run --omit=dev build
 
 # Runtime stage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "build/index",
   "types": "build/index",
   "files": [


### PR DESCRIPTION
## Summary

Reorganize agent dockerfile to take better advantage of layer caching by moving the dependency installation step before the copying of source code and building steps.

<!-- One paragraph explanation of the feature. -->

## Motivation

Speed up docker builds.

<!-- Why are we doing this? What use cases does it support? What is the expected outcome? -->

## Describe alternatives you've considered

Wait longer for builds.

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->