### PR TITLE
Expose ping endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/veritable-cloudagent",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aries-framework/anoncreds": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "build/index",
   "type": "module",
   "types": "build/index",

--- a/src/controllers/connections/ConnectionController.ts
+++ b/src/controllers/connections/ConnectionController.ts
@@ -24,6 +24,22 @@ export class ConnectionController extends Controller {
   }
 
   /**
+   * Send a trust ping to an established connection
+   * @param connectionId the id of the connection for which to accept the response
+   * @param responseRequested do we want a response to our ping
+   * @param withReturnRouting do we want a response at the time of posting
+   * @returns TrustPingMessage
+   */
+  @Post('/:connectionId/send-ping')
+  public async sendPing(
+    @Path('connectionId') connectionId: string,
+    @Query('responseRequested') responseRequested: boolean = true,
+    @Query('withReturnRouting') withReturnRouting?: boolean
+  ) {
+    return this.agent.connections.sendPing(connectionId, { responseRequested, withReturnRouting })
+  }
+
+  /**
    * Retrieve all connections records
    * @param alias Alias
    * @param state Connection state

--- a/src/events/TrustPingEvents.ts
+++ b/src/events/TrustPingEvents.ts
@@ -1,0 +1,35 @@
+import {
+  TrustPingEventTypes,
+  type Agent,
+  type TrustPingReceivedEvent,
+  type TrustPingResponseReceivedEvent,
+} from '@aries-framework/core'
+
+import type { ServerConfig } from '../utils/ServerConfig.js'
+import { sendWebSocketEvent } from './WebSocketEvents.js'
+import { sendWebhookEvent } from './WebhookEvent.js'
+
+export const trustPingEvents = async (agent: Agent, config: ServerConfig) => {
+  const eventHandler = async (event: TrustPingReceivedEvent | TrustPingResponseReceivedEvent) => {
+    const record = event.payload.connectionRecord
+    const body = record.toJSON()
+
+    // Only send webhook if webhook url is configured
+    if (config.webhookUrl) {
+      await sendWebhookEvent(config.webhookUrl + '/trust-ping', body, agent.config.logger)
+    }
+
+    if (config.socketServer) {
+      // Always emit websocket event to clients (could be 0)
+      sendWebSocketEvent(config.socketServer, {
+        ...event,
+        payload: {
+          message: event.payload.message.toJSON(),
+          basicMessageRecord: event.payload.connectionRecord.toJSON(),
+        },
+      })
+    }
+  }
+  agent.events.on(TrustPingEventTypes.TrustPingReceivedEvent, eventHandler)
+  agent.events.on(TrustPingEventTypes.TrustPingResponseReceivedEvent, eventHandler)
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { basicMessageEvents } from './events/BasicMessageEvents.js'
 import { connectionEvents } from './events/ConnectionEvents.js'
 import { credentialEvents } from './events/CredentialEvents.js'
 import { proofEvents } from './events/ProofEvents.js'
+import { trustPingEvents } from './events/TrustPingEvents.js'
 import { RegisterRoutes } from './routes/routes.js'
 import { errorHandler } from './error.js'
 import PolicyAgent from './policyAgent/index.js'
@@ -37,6 +38,7 @@ export const setupServer = async (agent: RestAgent, config: ServerConfig) => {
     connectionEvents(agent, config)
     credentialEvents(agent, config)
     proofEvents(agent, config)
+    trustPingEvents(agent, config)
   }
 
   // Use body parser to read sent json payloads

--- a/tests/unit/utils/helpers.ts
+++ b/tests/unit/utils/helpers.ts
@@ -13,6 +13,7 @@ import {
   OutOfBandInvitation,
   ConnectionInvitationMessage,
   DidDocument,
+  TrustPingMessage,
 } from '@aries-framework/core'
 import { JsonEncoder } from '@aries-framework/core/build/utils/JsonEncoder.js'
 import { randomUUID } from 'crypto'
@@ -387,6 +388,14 @@ export function getTestProof() {
     },
   }
   return JsonTransformer.fromJSON(json, ProofExchangeRecord)
+}
+
+export function getTestTrustPingMessage({
+  id = 'test',
+  comment = 'test-comment',
+  responseRequested = true,
+}: Partial<TrustPingMessage> = {}) {
+  return new TrustPingMessage({ id, comment, responseRequested })
 }
 
 export function getTestConnection({


### PR DESCRIPTION
Aries framework provides for a ["Trust Ping"](https://github.com/hyperledger/aries-rfcs/blob/main/features/0048-trust-ping/README.md) on established connections to verify connections status. This is useful in ensuring connections remain valid and the connected peer is responsive. This PR exposes this function as a new endpoint, and also relays the associated events through webhooks and websockets.