### PR TITLE
Remove log to file as this is not desired in an immutable container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/veritable-cloudagent",
-      "version": "0.7.19",
+      "version": "0.7.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@credo-ts/anoncreds": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "main": "build/index",
   "type": "module",
   "types": "build/index",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,12 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { type ILogObject, Logger } from 'tslog'
+import { Logger } from 'tslog'
 import { LogLevel, BaseLogger } from '@credo-ts/core'
-import { appendFileSync } from 'fs'
-
-function logToTransport(logObject: ILogObject) {
-  appendFileSync('logs.txt', JSON.stringify(logObject) + '\n')
-}
 
 export class TsLogger extends BaseLogger {
   private logger: Logger
@@ -29,21 +24,6 @@ export class TsLogger extends BaseLogger {
       name,
       minLevel: this.logLevel == LogLevel.off ? undefined : this.tsLogLevelMap[this.logLevel],
       ignoreStackLevels: 5,
-      attachedTransports: [
-        {
-          transportLogger: {
-            silly: logToTransport,
-            debug: logToTransport,
-            trace: logToTransport,
-            info: logToTransport,
-            warn: logToTransport,
-            error: logToTransport,
-            fatal: logToTransport,
-          },
-          // always log to file
-          minLevel: 'silly',
-        },
-      ],
     })
   }
 


### PR DESCRIPTION
Ticket [VR-95](https://digicatapult.atlassian.net/browse/VR-95)

Removes log to file as this is not desired when running in a immutable containerised environment.

We should also probably move to `pino` with this repo btw to match all our other logging formats, but that's beyond the scope of this ticket 

[VR-95]: https://digicatapult.atlassian.net/browse/VR-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ