### PR TITLE
Bug/array envs coerce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/veritable-cloudagent",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@credo-ts/anoncreds": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "main": "build/index",
   "type": "module",
   "types": "build/index",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,8 @@ import type { AskarWalletPostgresStorageConfig } from '@credo-ts/askar'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
+const splitFlat = (i: string[]) => i.map((i) => i.split(' ')).flat()
+
 const parsed = yargs(hideBin(process.argv))
   .command('start', 'Start AFJ Rest agent')
   .parserConfiguration({ 'parse-numbers': false })
@@ -21,6 +23,7 @@ const parsed = yargs(hideBin(process.argv))
   })
   .option('endpoint', {
     array: true,
+    coerce: splitFlat,
   })
   .option('log-level', {
     number: true,
@@ -38,13 +41,16 @@ const parsed = yargs(hideBin(process.argv))
     default: [],
     choices: ['http', 'ws'],
     array: true,
+    coerce: splitFlat,
   })
   .option('inbound-transport', {
     array: true,
     default: [],
-    coerce: (input: string[]) => {
+    coerce: (inputRaw: string[]) => {
       // Configured using config object
-      if (typeof input[0] === 'object') return input
+      if (typeof inputRaw[0] === 'object') return inputRaw
+
+      const input = splitFlat(inputRaw)
       if (input.length % 2 !== 0) {
         throw new Error(
           'Inbound transport should be specified as transport port pairs (e.g. --inbound-transport http 5002 ws 5003)'
@@ -98,9 +104,7 @@ const parsed = yargs(hideBin(process.argv))
   .option('webhook-url', {
     string: true,
     array: true,
-    coerce: (input: string[]) => {
-      return input.map((url) => url.split(' ')).flat()
-    },
+    coerce: splitFlat,
   })
   .option('admin-port', {
     number: true,


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

[VR-120](https://digicatapult.atlassian.net/browse/VR-120)

## High level description

Fixes a bug where we can't pass certain envs to configure cloudagent because they need to be interpretted as arrays.

## Detailed description

The basic issue is yargs doesn't handle env variable configuration for array parameters https://github.com/yargs/yargs/issues/821. The fix is to split each string with spaces and flatten

## Describe alternatives you've considered

Considered a more complex parsing scheme than just splitting on spaces. This would be necessary if we had config that might legitamately contain spaces. As this isn't currently the case I discounted this

## Operational impact

Fixes a bug, none

## Additional context

N/A


[VR-120]: https://digicatapult.atlassian.net/browse/VR-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ