### PR TITLE
Log level configuration switched to match other service norms

### DIFF
--- a/README_VERITABLE.md
+++ b/README_VERITABLE.md
@@ -58,7 +58,7 @@ The Envs are defined under `src > env.ts ` They are used to start up a container
 |WALLET_ID| Y| "walletId"| An id of the Agent's wallet|
 |WALLET_KEY| Y|"walletKey"| A key for the Agent's wallet|
 |ENDPOINT|Y|['http://localhost:5002', 'ws://localhost:5003']| An array of endpoint for the agent app, if passing as an `environment` variable in docker, please pass as a comma delimited string|
-|LOG_LEVEL|Y| info| Log level for the app |
+|LOG_LEVEL|Y| info| Log level for the app. Choices are trace, debug, info, warn, error or silent |
 |USE_DID_SOV_PREFIX_WHERE_ALLOWED|N|false|Allows the usage of 'sov' prefix in DIDs where possible|
 |USE_DID_KEY_IN_PROTOCOLS|N|true| Allows the use of DID keys in protocols|
 |OUTBOUND_TRANSPORT|Y|['http', 'ws']|Specifies the type of outbound transport|
@@ -85,20 +85,6 @@ The Envs are defined under `src > env.ts ` They are used to start up a container
 |VERIFIED_DRPC_OPTIONS_REQUEST_TIMEOUT_MS|N|5000| Timeout in ms for DRCP requests|
 |VERIFIED_DRPC_OPTIONS_PROOF_REQUEST_OPTIONS|Y|`{"protocolVersion": "v2", "proofFormats": {"anoncreds": {"name": "drpc-proof-request", "version": "1.0", "requested_attributes": {"companiesHouseNumberExists": {"name": "companiesHouseNumber"}}}}}` |Options for proof request|
 |VERIFIED_DRPC_OPTIONS_CRED_DEF_ID|N|"some-cred-def-id"|Credential definition id for verified DRPC|
-
-#### Logging
-
-The LOG_LEVEL options can be changed by importing the LogLevel eenum from credo-ts: `import { LogLevel } from '@credo-ts/core'` and using it: `LogLevel.info`.
-the options for LOG_LEVEL are:
-| :------: |
-|test = 0|
-|trace = 1|
-|debug = 2|
-|info = 3|
-|warn = 4|
-|error = 5|
-|fatal = 6|
-|off = 7|
 
 ### Using Docker (easiest)
 

--- a/docker-compose-integration-tests.yml
+++ b/docker-compose-integration-tests.yml
@@ -43,7 +43,7 @@ services:
       - CHARLIE_BASE_URL=http://charlie:3000
       - CHARLIE_DID
       - CHARLIE_PRIV_KEY
-      - LOG_LEVEL=1
+      - LOG_LEVEL=debug
     command: ['npm', 'run', 'test:integration']
     networks:
       - testnet

--- a/docker-compose-testnet.yml
+++ b/docker-compose-testnet.yml
@@ -31,7 +31,7 @@ services:
       alice-postgres:
         condition: service_healthy
     environment:
-      - LOG_LEVEL=1
+      - LOG_LEVEL=debug
       #- VERIFIED_DRPC_OPTIONS__CRED_DEF_ID=ipfs://bafkreifrnrqbr4ofsuoenr2xzsyc5qhwectsq7lovhohw47rhgxhkig4de
       - PERSONA_TITLE=TA
       - PERSONA_COLOR=#eddedf
@@ -65,7 +65,7 @@ services:
       bob-postgres:
         condition: service_healthy
     environment:
-      - LOG_LEVEL=1
+      - LOG_LEVEL=debug
       #- VERIFIED_DRPC_OPTIONS__CRED_DEF_ID=ipfs://bafkreifrnrqbr4ofsuoenr2xzsyc5qhwectsq7lovhohw47rhgxhkig4de
       - PERSONA_TITLE=OEM
       - PERSONA_COLOR=#dfedde
@@ -99,7 +99,7 @@ services:
       charlie-postgres:
         condition: service_healthy
     environment:
-      - LOG_LEVEL=1
+      - LOG_LEVEL=debug
       #- VERIFIED_DRPC_OPTIONS__CRED_DEF_ID=ipfs://bafkreifrnrqbr4ofsuoenr2xzsyc5qhwectsq7lovhohw47rhgxhkig4de
       - PERSONA_TITLE=Supplier
       - PERSONA_COLOR=#dedfed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/veritable-cloudagent",
-      "version": "0.9.23",
+      "version": "0.9.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@credo-ts/anoncreds": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "main": "build/index",
   "type": "module",
   "types": "build/index",

--- a/samples/sample.ts
+++ b/samples/sample.ts
@@ -10,6 +10,7 @@ const run = async () => {
     port: 3001,
     endpoints: [endpoint],
     name: 'Aries Test Agent',
+    logLevel: 'debug',
   })
 
   const conf = {

--- a/samples/sampleWithApp.ts
+++ b/samples/sampleWithApp.ts
@@ -12,6 +12,7 @@ const run = async () => {
     port: 3001,
     endpoints: [endpoint],
     name: 'Aries Test Agent',
+    logLevel: 'debug',
   })
 
   const app = express()

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -6,13 +6,13 @@ import {
   type WalletConfig,
   HttpOutboundTransport,
   WsOutboundTransport,
-  LogLevel,
   Agent,
   AutoAcceptCredential,
   AutoAcceptProof,
 } from '@credo-ts/core'
 import { agentDependencies, HttpInboundTransport, WsInboundTransport } from '@credo-ts/node'
 import WebSocket from 'ws'
+import { LevelWithSilent } from 'pino'
 
 import type { VerifiedDrpcModuleConfigOptions } from './modules/verified-drpc/index.js'
 import { setupServer } from './server.js'
@@ -47,7 +47,7 @@ export interface AriesRestConfig {
   backupBeforeStorageUpdate?: boolean
   useDidKeyInProtocols?: boolean
   useDidSovPrefixWhereAllowed?: boolean
-  logLevel?: LogLevel
+  logLevel: LevelWithSilent
   inboundTransports?: InboundTransport[]
   outboundTransports?: Transports[]
   autoAcceptMediationRequests?: boolean
@@ -88,7 +88,7 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     ...afjConfig
   } = restConfig
 
-  const logger = new PinoLogger(logLevel ?? LogLevel.error)
+  const logger = new PinoLogger(logLevel)
 
   const agentConfig: InitConfig = {
     ...afjConfig,

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,3 @@
-import { LogLevel } from '@credo-ts/core'
 import * as dotenv from 'dotenv'
 import * as envalid from 'envalid'
 import { makeValidator } from 'envalid'
@@ -46,7 +45,11 @@ const envConfig = {
     default: ['http://localhost:5002', 'ws://localhost:5003'],
     devDefault: ['http://localhost:5002', 'ws://localhost:5003'],
   }),
-  LOG_LEVEL: envalid.num({ default: LogLevel.info, devDefault: LogLevel.info }),
+  LOG_LEVEL: envalid.str({
+    default: 'info',
+    devDefault: 'debug',
+    choices: ['trace', 'debug', 'info', 'warn', 'error', 'silent'],
+  }),
   USE_DID_SOV_PREFIX_WHERE_ALLOWED: envalid.bool({ default: false, devDefault: true }),
   USE_DID_KEY_IN_PROTOCOLS: envalid.bool({ default: true, devDefault: true }),
   OUTBOUND_TRANSPORT: stringArray({ default: ['http', 'ws'], devDefault: ['http', 'ws'] }),

--- a/src/utils/agent.ts
+++ b/src/utils/agent.ts
@@ -12,7 +12,6 @@ import {
   Agent,
   AutoAcceptCredential,
   AutoAcceptProof,
-  LogLevel,
   ConnectionsModule,
   CredentialsModule,
   HttpOutboundTransport,
@@ -29,7 +28,7 @@ import { anoncreds } from '@hyperledger/anoncreds-nodejs'
 
 import VeritableAnonCredsRegistry from '../anoncreds/index.js'
 import Ipfs from '../ipfs/index.js'
-import PinoLogger from './logger.js'
+import PinoLogger, { type LogLevel } from './logger.js'
 
 export interface RestAgentModules extends ModulesMap {
   connections: ConnectionsModule
@@ -122,8 +121,18 @@ export const getAgentModules = (options: {
   }
 }
 
-export const setupAgent = async ({ name, endpoints, port }: { name: string; endpoints: string[]; port: number }) => {
-  const logger = new PinoLogger(LogLevel.debug)
+export const setupAgent = async ({
+  name,
+  endpoints,
+  port,
+  logLevel,
+}: {
+  name: string
+  endpoints: string[]
+  port: number
+  logLevel: LogLevel
+}) => {
+  const logger = new PinoLogger(logLevel)
 
   const modules = getAgentModules({
     autoAcceptConnections: true,

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,23 +1,37 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { pino, Logger } from 'pino'
-import { LogLevel, BaseLogger } from '@credo-ts/core'
+import { pino, Logger, LevelWithSilent } from 'pino'
+import { LogLevel as CredoLogLevel, BaseLogger } from '@credo-ts/core'
+
+const tsLogLevelMap = {
+  silent: CredoLogLevel.off,
+  trace: CredoLogLevel.trace,
+  debug: CredoLogLevel.debug,
+  info: CredoLogLevel.info,
+  warn: CredoLogLevel.warn,
+  error: CredoLogLevel.error,
+  fatal: CredoLogLevel.fatal,
+} as const
+
+const invTsLogLevelMap = {
+  [CredoLogLevel.off]: 'silent' as const,
+  [CredoLogLevel.test]: 'trace' as const,
+  [CredoLogLevel.trace]: 'trace' as const,
+  [CredoLogLevel.debug]: 'debug' as const,
+  [CredoLogLevel.info]: 'info' as const,
+  [CredoLogLevel.warn]: 'warn' as const,
+  [CredoLogLevel.error]: 'error' as const,
+  [CredoLogLevel.fatal]: 'fatal' as const,
+} as const
+
+export type LogLevel = LevelWithSilent
 
 export default class PinoLogger extends BaseLogger {
   private logger: Logger
 
   // Map our log levels to tslog levels
-  private tsLogLevelMap = {
-    [LogLevel.test]: 'silent', // pino does not have 'silly' so used silent for .test() method
-    [LogLevel.trace]: 'trace',
-    [LogLevel.debug]: 'debug',
-    [LogLevel.info]: 'info',
-    [LogLevel.warn]: 'warn',
-    [LogLevel.error]: 'error',
-    [LogLevel.fatal]: 'fatal',
-  } as const
 
-  public constructor(logLevel: LogLevel) {
-    super(logLevel)
+  public constructor(logLevel: LevelWithSilent) {
+    super(tsLogLevelMap[logLevel])
 
     this.logger = pino(
       {
@@ -29,37 +43,37 @@ export default class PinoLogger extends BaseLogger {
     )
   }
 
-  private log(level: Exclude<LogLevel, LogLevel.off>, message: string, data?: Record<string, any>): void {
-    const tsLogLevel = this.tsLogLevelMap[level]
+  private log(level: Exclude<CredoLogLevel, CredoLogLevel.off>, message: string, data?: Record<string, any>): void {
+    const tsLogLevel = invTsLogLevelMap[level]
     if (data) return this.logger[tsLogLevel]('%s %o', message, data)
     this.logger[tsLogLevel](message)
   }
 
   public test(message: string, data?: Record<string, any>): void {
-    this.log(LogLevel.test, message, data)
+    this.log(CredoLogLevel.test, message, data)
   }
 
   public trace(message: string, data?: Record<string, any>): void {
-    this.log(LogLevel.trace, message, data)
+    this.log(CredoLogLevel.trace, message, data)
   }
 
   public debug(message: string, data?: Record<string, any>): void {
-    this.log(LogLevel.debug, message, data)
+    this.log(CredoLogLevel.debug, message, data)
   }
 
   public info(message: string, data?: Record<string, any>): void {
-    this.log(LogLevel.info, message, data)
+    this.log(CredoLogLevel.info, message, data)
   }
 
   public warn(message: string, data?: Record<string, any>): void {
-    this.log(LogLevel.warn, message, data)
+    this.log(CredoLogLevel.warn, message, data)
   }
 
   public error(message: string, data?: Record<string, any>): void {
-    this.log(LogLevel.error, message, data)
+    this.log(CredoLogLevel.error, message, data)
   }
 
   public fatal(message: string, data?: Record<string, any>): void {
-    this.log(LogLevel.fatal, message, data)
+    this.log(CredoLogLevel.fatal, message, data)
   }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -37,7 +37,7 @@ export default class PinoLogger extends BaseLogger {
       {
         name: 'veritable-cloudagent',
         timestamp: true,
-        level: 'debug',
+        level: logLevel,
       },
       process.stdout
     )

--- a/tests/unit/utils/helpers.ts
+++ b/tests/unit/utils/helpers.ts
@@ -26,6 +26,7 @@ export async function getTestAgent(name: string, port: number) {
     endpoints: [`http://localhost:${port}`],
     // add some randomness to ensure test isolation
     name: `${name} (${randomUUID()})`,
+    logLevel: 'silent',
   })
 }
 


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

[VR-161](https://digicatapult.atlassian.net/browse/VR-161)

## High level description

Log level is now configured use the usual pino log levels

## Detailed description

From when we used TSLogger as the logger (inherited form the credo-ts examples) log levels were configured using numeric indexes. This is inconsistent with how we confiugure logging elsewhere. This change makes that consistent and also fixes the fact that all log levels are always interpretted as `debug`

## Describe alternatives you've considered

N/A

## Operational impact

None as this isn't yet deployed

## Additional context

N/A


[VR-161]: https://digicatapult.atlassian.net/browse/VR-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ