### PR TITLE
Shrink docker image from 1.64GB -> 730MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,7 @@ CMD ["npm", "run", "test"]
 FROM node:lts-bookworm-slim AS production
 
 # # Need curl for healthcheck
-# RUN apt-get install -y curl
-# RUN apt clean
+RUN apt-get update && apt-get install -y curl
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:lts AS build
+FROM node:lts-bookworm AS build
 
 ARG NODE_ENV=development
 ENV NODE_ENV=${NODE_ENV}
@@ -14,7 +14,7 @@ RUN npm run build
 
 
 # Node_Modules stage
-FROM node:lts AS modules
+FROM node:lts-bookworm AS modules
 
 WORKDIR /app
 
@@ -39,7 +39,7 @@ CMD ["npm", "run", "test"]
 # Production stage
 FROM node:lts-bookworm-slim AS production
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl openssl
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ CMD ["npm", "run", "test"]
 # Production stage
 FROM node:lts-bookworm-slim AS production
 
-# # Need curl for healthcheck
+# Need curl for healthcheck
 RUN apt-get update && apt-get install -y curl
 
 ARG NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,20 +28,18 @@ CMD ["npm", "run", "test"]
 
 
 # Production stage
-FROM node:lts AS production
-# NB Debian bookworm-slim doesn't include OpenSSL
+FROM node:current-alpine AS production
 
 # Need curl for healthcheck
-RUN apt-get update && \
-	apt-get install -y curl
-
+RUN apk add --no-cache curl openssl
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /www
 
-COPY --from=build /app/package.json /app/package-lock.json ./
+COPY --from=build /app/package*.json ./
 COPY --from=build /app/build ./build
-RUN npm ci && npm cache clean --force
+COPY --from=build /app/node_modules ./node_modules
+RUN npm prune --omit=dev
 
 EXPOSE 3000 5002 5003
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,11 @@ CMD ["npm", "run", "test"]
 
 
 # Production stage
-FROM node:current-alpine AS production
+FROM node:lts-bookworm-slim AS production
 
-# Need curl for healthcheck
-RUN apk add --no-cache curl openssl
+# # Need curl for healthcheck
+# RUN apt-get install -y curl
+# RUN apt clean
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ARG NODE_ENV=development
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /app
 
-COPY package.json package-lock.json ./
-RUN npm ci && npm cache clean --force
+COPY package*.json ./
+RUN npm ci
 
 COPY tsoa.json tsconfig.json .swcrc ./
 COPY src ./src

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ FROM node:current-alpine AS production
 
 # Need curl for healthcheck
 RUN apk add --no-cache curl openssl
+
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /www

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY tsoa.json tsconfig.json .swcrc ./
 COPY src ./src
 RUN npm run build
 
+
 # Node_Modules stage
 FROM node:lts AS modules
 
@@ -19,6 +20,7 @@ WORKDIR /app
 
 COPY package*.json ./
 RUN npm ci --omit=dev
+
 
 # Test stage
 FROM build AS test

--- a/docker-compose-integration-tests.yml
+++ b/docker-compose-integration-tests.yml
@@ -1,6 +1,6 @@
 # Run stack and integration tests with:
 #
-# docker-compose \
+# docker compose \
 #   -f docker-compose-testnet.yml \
 #   -f docker-compose-integration-tests.yml \
 #   up --build --exit-code-from integration-tests

--- a/docker-compose-testnet.yml
+++ b/docker-compose-testnet.yml
@@ -1,4 +1,4 @@
-#docker-compose -f docker-compose-testnet.yml up --build -d
+# docker compose -f docker-compose-testnet.yml up --build -d
 
 ##################################################################################
 ## Docker-Compose for a 3-agent testnet + 3-node private IPFS cluster ############

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-#docker-compose -f docker-compose-agent-ipfs.yml up --build -d
+# docker compose -f docker-compose-agent-ipfs.yml up --build -d
 
 ##################################################################################
 ## Docker-Compose for a Single agent + Single IPFS node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.12.18",
+  "version": "0.12.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/veritable-cloudagent",
-      "version": "0.12.18",
+      "version": "0.12.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@credo-ts/anoncreds": "^0.5.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.12.18",
+  "version": "0.12.19",
   "main": "build/index",
   "type": "module",
   "types": "build/index",


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Chore

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or Github Issue, please provide the ticket URL here. -->

## High level description

Change docker build process and underlying image to shrink final production image to 734MB

## Detailed description

Rebased final image on `node:lts-bookworm-slim`
Using `dive` discovered that `npm prune --omit=dev` leaves a lot of unnecessary cache, so moved this to separate build stage and copied `node_modules` into final production image

Some other minor changes


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
