### PR TITLE
Fix colour variable name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.12.97",
+  "version": "0.12.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/veritable-cloudagent",
-      "version": "0.12.97",
+      "version": "0.12.98",
       "license": "Apache-2.0",
       "dependencies": {
         "@credo-ts/anoncreds": "^0.5.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.12.98",
+  "version": "0.12.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/veritable-cloudagent",
-      "version": "0.12.98",
+      "version": "0.12.99",
       "license": "Apache-2.0",
       "dependencies": {
         "@credo-ts/anoncreds": "^0.5.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.12.97",
+  "version": "0.12.98",
   "main": "build/index",
   "type": "module",
   "types": "build/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.12.98",
+  "version": "0.12.99",
   "main": "build/index",
   "type": "module",
   "types": "build/index",

--- a/src/env.ts
+++ b/src/env.ts
@@ -104,7 +104,7 @@ const envConfig = {
   ADMIN_PORT: envalid.num({ default: 3000, devDefault: 3000 }),
   IPFS_ORIGIN: envalid.str({ default: 'http://ipfs0:5001', devDefault: 'http://ipfs0:5001' }),
   PERSONA_TITLE: envalid.str({ default: 'Veritable Cloudagent' }),
-  PERONA_COLOR: envalid.str({ default: 'white' }),
+  PERSONA_COLOR: envalid.str({ default: 'white' }),
   STORAGE_TYPE: envalid.str({ default: 'postgres', choices: ['sqlite', 'postgres'] }),
   POSTGRES_HOST: envalid.str({ default: 'postgres', devDefault: 'postgres' }),
   POSTGRES_PORT: envalid.str({ default: '5432', devDefault: '5432' }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ const socketServer = new WebSocket.Server({ noServer: true })
 const app = await setupServer(agent, logger, {
   webhookUrl: env.get('WEBHOOK_URL'),
   personaTitle: env.get('PERSONA_TITLE'),
-  personaColor: env.get('PERONA_COLOR'),
+  personaColor: env.get('PERSONA_COLOR'),
   socketServer,
 })
 


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [x] Chore

## Linked tickets

There's a typo in the name of the variable controlling the Swagger UI's background colour. The README has the correct name, but it doesn't correspond to what's in the source.

## Operational impact

None. It's a non-functional UI element.