### PR TITLE
Disables anoncreds-nodejs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,10 @@
 		{
 			"matchPackagePatterns": ["^@credo-ts/"],
 			"enabled": false
+		},
+		{
+			"matchPackageNames": ["@hyperledger/anoncreds-nodejs"],
+			"enabled": false
 		}
 	]
 }


### PR DESCRIPTION
Disables renovate updating anoncreds-nodejs as it will currently break until credo is updated.

# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix
- [X] Chore

## Linked tickets

N/A

## High level description

This disabled renovate updating anoncreds-nodejs.

## Detailed description

The Credo team have said not to update to `0.3.x` until the new version of credo is released.


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
