### PR TITLE
Update to Undici 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.18.33",
+  "version": "0.18.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/veritable-cloudagent",
-      "version": "0.18.33",
+      "version": "0.18.34",
       "license": "Apache-2.0",
       "dependencies": {
         "@2060.io/credo-ts-didcomm-media-sharing": "^0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.18.32",
+  "version": "0.18.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/veritable-cloudagent",
-      "version": "0.18.32",
+      "version": "0.18.33",
       "license": "Apache-2.0",
       "dependencies": {
         "@2060.io/credo-ts-didcomm-media-sharing": "^0.0.3",
@@ -34,7 +34,7 @@
         "swagger-ui-express": "^5.0.1",
         "tsoa": "^6.6.0",
         "tsyringe": "^4.10.0",
-        "undici": "^7.25.0",
+        "undici": "^8.1.0",
         "ws": "^8.20.0",
         "zod": "^4.3.6"
       },
@@ -2906,20 +2906,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/@expo/cli/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@expo/cli/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -3012,20 +2998,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@expo/config/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@expo/devcert": {
@@ -3205,20 +3177,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@expo/image-utils/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@expo/json-file": {
@@ -9584,36 +9542,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/chokidar/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -11539,20 +11467,6 @@
         "react-native-worklets": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/exponential-backoff": {
@@ -18649,12 +18563,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.1.0.tgz",
+      "integrity": "sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.18.32",
+  "version": "0.18.33",
   "main": "build/index",
   "type": "module",
   "types": "build/index",
@@ -68,7 +68,7 @@
     "swagger-ui-express": "^5.0.1",
     "tsoa": "^6.6.0",
     "tsyringe": "^4.10.0",
-    "undici": "^7.25.0",
+    "undici": "^8.1.0",
     "ws": "^8.20.0",
     "zod": "^4.3.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/veritable-cloudagent",
-  "version": "0.18.33",
+  "version": "0.18.34",
   "main": "build/index",
   "type": "module",
   "types": "build/index",

--- a/src/ipfs/__tests__/fixtures/ipfs.ts
+++ b/src/ipfs/__tests__/fixtures/ipfs.ts
@@ -1,44 +1,61 @@
 import { after, before } from 'mocha'
 import { Dispatcher, getGlobalDispatcher, MockAgent, setGlobalDispatcher } from 'undici'
 
-export const withIpfsCatResponse = (responses: { cid: string; code: number; body: string | object | Buffer }[]) => {
+type IpfsMockResponse = {
+  code: number
+  body?: string | object | Buffer
+  delayMs?: number
+}
+
+export const withIpfsCatResponse = (responses: ({ cid: string } & IpfsMockResponse)[]) => {
   const ipfsOrigin = `http://ipfs`
   let originalDispatcher: Dispatcher
   let mockAgent: MockAgent
   before(function () {
     originalDispatcher = getGlobalDispatcher()
     mockAgent = new MockAgent()
+    mockAgent.disableNetConnect()
     setGlobalDispatcher(mockAgent)
     const mockIpfs = mockAgent.get(`http://ipfs`)
 
-    for (const { cid, code, body } of responses) {
-      mockIpfs
+    for (const { cid, code, body, delayMs } of responses) {
+      const scope = mockIpfs
         .intercept({
           path: `/api/v0/cat?arg=${cid}`,
           method: 'POST',
         })
-        .reply(code, body)
+        .reply(code, body ?? '')
+
+      if (delayMs !== undefined) {
+        scope.delay(delayMs)
+      }
     }
   })
 
-  after(function () {
-    setGlobalDispatcher(originalDispatcher)
+  after(async function () {
+    try {
+      mockAgent.assertNoPendingInterceptors()
+    } finally {
+      setGlobalDispatcher(originalDispatcher)
+      await mockAgent.close()
+    }
   })
 
   return { ipfsOrigin }
 }
-export const withIpfsAddResponse = (responses: { code: number; cid: unknown; body: Buffer }[]) => {
+export const withIpfsAddResponse = (responses: ({ cid: unknown } & IpfsMockResponse)[]) => {
   const ipfsOrigin = `http://ipfs`
   let originalDispatcher: Dispatcher
   let mockAgent: MockAgent
   before(function () {
     originalDispatcher = getGlobalDispatcher()
     mockAgent = new MockAgent()
+    mockAgent.disableNetConnect()
     setGlobalDispatcher(mockAgent)
     const mockIpfs = mockAgent.get(`http://ipfs`)
 
-    for (const { code, cid } of responses) {
-      mockIpfs
+    for (const { code, cid, body, delayMs } of responses) {
+      const scope = mockIpfs
         .intercept({
           path: '/api/v0/add?cid-version=1',
           method: 'POST',
@@ -49,12 +66,21 @@ export const withIpfsAddResponse = (responses: { code: number; cid: unknown; bod
             return asArr.length === 1 && asArr[0][0] === 'file'
           },
         })
-        .reply(code, { Hash: cid })
+        .reply(code, body ?? { Hash: cid })
+
+      if (delayMs !== undefined) {
+        scope.delay(delayMs)
+      }
     }
   })
 
-  after(function () {
-    setGlobalDispatcher(originalDispatcher)
+  after(async function () {
+    try {
+      mockAgent.assertNoPendingInterceptors()
+    } finally {
+      setGlobalDispatcher(originalDispatcher)
+      await mockAgent.close()
+    }
   })
 
   return { ipfsOrigin }

--- a/src/ipfs/__tests__/fixtures/ipfs.ts
+++ b/src/ipfs/__tests__/fixtures/ipfs.ts
@@ -1,13 +1,7 @@
 import { after, before } from 'mocha'
 import { Dispatcher, getGlobalDispatcher, MockAgent, setGlobalDispatcher } from 'undici'
 
-type IpfsMockResponse = {
-  code: number
-  body?: string | object | Buffer
-  delayMs?: number
-}
-
-export const withIpfsCatResponse = (responses: ({ cid: string } & IpfsMockResponse)[]) => {
+export const withIpfsCatResponse = (responses: { cid: string; code: number; body: string | object | Buffer }[]) => {
   const ipfsOrigin = `http://ipfs`
   let originalDispatcher: Dispatcher
   let mockAgent: MockAgent
@@ -18,17 +12,13 @@ export const withIpfsCatResponse = (responses: ({ cid: string } & IpfsMockRespon
     setGlobalDispatcher(mockAgent)
     const mockIpfs = mockAgent.get(`http://ipfs`)
 
-    for (const { cid, code, body, delayMs } of responses) {
-      const scope = mockIpfs
+    for (const { cid, code, body } of responses) {
+      mockIpfs
         .intercept({
           path: `/api/v0/cat?arg=${cid}`,
           method: 'POST',
         })
-        .reply(code, body ?? '')
-
-      if (delayMs !== undefined) {
-        scope.delay(delayMs)
-      }
+        .reply(code, body)
     }
   })
 
@@ -43,7 +33,7 @@ export const withIpfsCatResponse = (responses: ({ cid: string } & IpfsMockRespon
 
   return { ipfsOrigin }
 }
-export const withIpfsAddResponse = (responses: ({ cid: unknown } & IpfsMockResponse)[]) => {
+export const withIpfsAddResponse = (responses: { code: number; cid: unknown; body: Buffer }[]) => {
   const ipfsOrigin = `http://ipfs`
   let originalDispatcher: Dispatcher
   let mockAgent: MockAgent
@@ -54,8 +44,8 @@ export const withIpfsAddResponse = (responses: ({ cid: unknown } & IpfsMockRespo
     setGlobalDispatcher(mockAgent)
     const mockIpfs = mockAgent.get(`http://ipfs`)
 
-    for (const { code, cid, body, delayMs } of responses) {
-      const scope = mockIpfs
+    for (const { code, cid } of responses) {
+      mockIpfs
         .intercept({
           path: '/api/v0/add?cid-version=1',
           method: 'POST',
@@ -66,11 +56,7 @@ export const withIpfsAddResponse = (responses: ({ cid: unknown } & IpfsMockRespo
             return asArr.length === 1 && asArr[0][0] === 'file'
           },
         })
-        .reply(code, body ?? { Hash: cid })
-
-      if (delayMs !== undefined) {
-        scope.delay(delayMs)
-      }
+        .reply(code, { Hash: cid })
     }
   })
 

--- a/src/ipfs/__tests__/index.test.ts
+++ b/src/ipfs/__tests__/index.test.ts
@@ -1,28 +1,13 @@
 import { expect } from 'chai'
 import { afterEach, beforeEach, describe, it } from 'mocha'
-import { restore as sinonRestore, stub, useFakeTimers, type SinonFakeTimers } from 'sinon'
+import { useFakeTimers, type SinonFakeTimers } from 'sinon'
 
 import Ipfs from '../index.js'
 import { withIpfsAddResponse, withIpfsCatResponse } from './fixtures/ipfs.js'
 
 const ipfsTimeoutMs = 15000
 const shortTimeoutMs = 1
-
-const stubHangingFetch = () => {
-  // Simulate a fetch request that never resolves unless explicitly aborted.
-  stub(globalThis, 'fetch').callsFake((_request: Parameters<typeof fetch>[0], init?: RequestInit) => {
-    return new Promise<Response>((_, reject) => {
-      const rejectOnAbort = () => reject(init?.signal?.reason ?? new Error('The operation was aborted.'))
-
-      if (init?.signal?.aborted) {
-        rejectOnAbort()
-        return
-      }
-
-      init?.signal?.addEventListener('abort', rejectOnAbort, { once: true })
-    })
-  })
-}
+const delayedBeyondTimeoutMs = shortTimeoutMs + 10
 
 describe('ipfs', function () {
   it('creates an IPFS instance when origin is a valid URL', function () {
@@ -39,6 +24,7 @@ describe('ipfs', function () {
     const { ipfsOrigin } = withIpfsCatResponse([
       { cid: 'okCid', code: 200, body: Buffer.from('1234', 'hex') },
       { cid: 'badCid', code: 400, body: Buffer.from('1234', 'hex') },
+      { cid: 'timeoutCid', code: 200, body: Buffer.from('1234', 'hex'), delayMs: delayedBeyondTimeoutMs },
     ])
 
     beforeEach(function () {
@@ -47,7 +33,6 @@ describe('ipfs', function () {
 
     afterEach(function () {
       clock?.restore()
-      sinonRestore()
     })
 
     it('returns buffer contents', async function () {
@@ -70,10 +55,9 @@ describe('ipfs', function () {
 
     it('throws timeout when request exceeds timeout', async function () {
       clock = useFakeTimers({ toFake: ['setTimeout'] })
-      stubHangingFetch()
 
-      const ipfs = new Ipfs('http://ipfs', shortTimeoutMs)
-      const errorPromise = ipfs.getFile('testCid').then(
+      const ipfs = new Ipfs(ipfsOrigin, shortTimeoutMs)
+      const errorPromise = ipfs.getFile('timeoutCid').then(
         () => {
           throw new Error('Expected an error')
         },
@@ -83,14 +67,19 @@ describe('ipfs', function () {
       await clock.tickAsync(shortTimeoutMs)
       const error = await errorPromise
 
-      expect(error.message).to.equal('Timeout fetching file testCid from IPFS')
+      expect(error.message).to.equal('Timeout fetching file timeoutCid from IPFS')
     })
   })
 
   describe('uploadFile', function () {
     const uploadBuffer = Buffer.from('hello', 'utf8')
     let clock: SinonFakeTimers | undefined
-    const { ipfsOrigin } = withIpfsAddResponse([{ cid: 'testCid', code: 200, body: uploadBuffer }])
+    const { ipfsOrigin } = withIpfsAddResponse([
+      { cid: 'testCid', code: 200 },
+      { cid: 'ignoredFor400', code: 400, body: '{}' },
+      { cid: 'ignoredInvalid', code: 200, body: '{"Hash":null}' },
+      { cid: 'ignoredTimeout', code: 200, body: '{"Hash":"late"}', delayMs: delayedBeyondTimeoutMs },
+    ])
 
     beforeEach(function () {
       clock = undefined
@@ -98,7 +87,6 @@ describe('ipfs', function () {
 
     afterEach(function () {
       clock?.restore()
-      sinonRestore()
     })
 
     it('returns uploaded CID on success', async function () {
@@ -108,9 +96,7 @@ describe('ipfs', function () {
     })
 
     it('throws when request fails (code 400)', async function () {
-      stub(globalThis, 'fetch').resolves(new Response('{}', { status: 400 }))
-
-      const ipfs = new Ipfs('http://ipfs', ipfsTimeoutMs)
+      const ipfs = new Ipfs(ipfsOrigin, ipfsTimeoutMs)
       const error = await ipfs.uploadFile(uploadBuffer).then(
         () => {
           throw new Error('Expected an error')
@@ -122,9 +108,7 @@ describe('ipfs', function () {
     })
 
     it('throws when response payload is invalid', async function () {
-      stub(globalThis, 'fetch').resolves(new Response('{"Hash":null}', { status: 200 }))
-
-      const ipfs = new Ipfs('http://ipfs', ipfsTimeoutMs)
+      const ipfs = new Ipfs(ipfsOrigin, ipfsTimeoutMs)
       const error = await ipfs.uploadFile(uploadBuffer).then(
         () => {
           throw new Error('Expected an error')
@@ -137,9 +121,8 @@ describe('ipfs', function () {
 
     it('throws timeout when upload exceeds timeout', async function () {
       clock = useFakeTimers({ toFake: ['setTimeout'] })
-      stubHangingFetch()
 
-      const ipfs = new Ipfs('http://ipfs', shortTimeoutMs)
+      const ipfs = new Ipfs(ipfsOrigin, shortTimeoutMs)
       const errorPromise = ipfs.uploadFile(uploadBuffer).then(
         () => {
           throw new Error('Expected an error')

--- a/src/ipfs/__tests__/index.test.ts
+++ b/src/ipfs/__tests__/index.test.ts
@@ -121,20 +121,25 @@ describe('ipfs', function () {
 
     it('throws timeout when request exceeds timeout', async function () {
       clock = useFakeTimers({ toFake: ['setTimeout'] })
-      await withDelayedIpfsMock('/api/v0/cat?arg=timeoutCid', Buffer.from('1234', 'hex'), delayedBeyondTimeoutMs, async () => {
-        const ipfs = new Ipfs(ipfsOrigin, shortTimeoutMs)
-        const errorPromise = ipfs.getFile('timeoutCid').then(
-          () => {
-            throw new Error('Expected an error')
-          },
-          (caughtError: unknown) => caughtError as Error
-        )
+      await withDelayedIpfsMock(
+        '/api/v0/cat?arg=timeoutCid',
+        Buffer.from('1234', 'hex'),
+        delayedBeyondTimeoutMs,
+        async () => {
+          const ipfs = new Ipfs(ipfsOrigin, shortTimeoutMs)
+          const errorPromise = ipfs.getFile('timeoutCid').then(
+            () => {
+              throw new Error('Expected an error')
+            },
+            (caughtError: unknown) => caughtError as Error
+          )
 
-        await clock?.tickAsync(shortTimeoutMs)
-        const error = await errorPromise
+          await clock?.tickAsync(shortTimeoutMs)
+          const error = await errorPromise
 
-        expect(error.message).to.equal('Timeout fetching file timeoutCid from IPFS')
-      })
+          expect(error.message).to.equal('Timeout fetching file timeoutCid from IPFS')
+        }
+      )
     })
   })
 

--- a/src/ipfs/__tests__/index.test.ts
+++ b/src/ipfs/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { afterEach, beforeEach, describe, it } from 'mocha'
 import { useFakeTimers, type SinonFakeTimers } from 'sinon'
+import { getGlobalDispatcher, MockAgent, setGlobalDispatcher, type Dispatcher } from 'undici'
 
 import Ipfs from '../index.js'
 import { withIpfsAddResponse, withIpfsCatResponse } from './fixtures/ipfs.js'
@@ -8,6 +9,72 @@ import { withIpfsAddResponse, withIpfsCatResponse } from './fixtures/ipfs.js'
 const ipfsTimeoutMs = 15000
 const shortTimeoutMs = 1
 const delayedBeyondTimeoutMs = shortTimeoutMs + 10
+const ipfsOrigin = 'http://ipfs'
+
+const withDelayedIpfsMock = async (
+  route: '/api/v0/cat?arg=timeoutCid' | '/api/v0/add?cid-version=1',
+  body: Buffer | string | object,
+  delayMs: number,
+  run: () => Promise<void>
+) => {
+  const originalDispatcher: Dispatcher = getGlobalDispatcher()
+  const mockAgent = new MockAgent()
+  mockAgent.disableNetConnect()
+  setGlobalDispatcher(mockAgent)
+
+  const mockIpfs = mockAgent.get(ipfsOrigin)
+  const intercept = mockIpfs.intercept({
+    path: route,
+    method: 'POST',
+    ...(route === '/api/v0/add?cid-version=1'
+      ? {
+          body: (calledBody: string) => {
+            const asBuf = calledBody as unknown as FormData
+            const asArr = [...asBuf.entries()]
+            return asArr.length === 1 && asArr[0][0] === 'file'
+          },
+        }
+      : {}),
+  })
+
+  intercept.reply(200, body).delay(delayMs)
+
+  try {
+    await run()
+    mockAgent.assertNoPendingInterceptors()
+  } finally {
+    setGlobalDispatcher(originalDispatcher)
+    await mockAgent.close()
+  }
+}
+
+const withIpfsAddStatusMock = async (statusCode: number, body: string, run: () => Promise<void>) => {
+  const originalDispatcher: Dispatcher = getGlobalDispatcher()
+  const mockAgent = new MockAgent()
+  mockAgent.disableNetConnect()
+  setGlobalDispatcher(mockAgent)
+
+  const mockIpfs = mockAgent.get(ipfsOrigin)
+  mockIpfs
+    .intercept({
+      path: '/api/v0/add?cid-version=1',
+      method: 'POST',
+      body: (calledBody: string) => {
+        const asBuf = calledBody as unknown as FormData
+        const asArr = [...asBuf.entries()]
+        return asArr.length === 1 && asArr[0][0] === 'file'
+      },
+    })
+    .reply(statusCode, body)
+
+  try {
+    await run()
+    mockAgent.assertNoPendingInterceptors()
+  } finally {
+    setGlobalDispatcher(originalDispatcher)
+    await mockAgent.close()
+  }
+}
 
 describe('ipfs', function () {
   it('creates an IPFS instance when origin is a valid URL', function () {
@@ -21,10 +88,9 @@ describe('ipfs', function () {
 
   describe('getFile', function () {
     let clock: SinonFakeTimers | undefined
-    const { ipfsOrigin } = withIpfsCatResponse([
+    const { ipfsOrigin: mockIpfsOrigin } = withIpfsCatResponse([
       { cid: 'okCid', code: 200, body: Buffer.from('1234', 'hex') },
       { cid: 'badCid', code: 400, body: Buffer.from('1234', 'hex') },
-      { cid: 'timeoutCid', code: 200, body: Buffer.from('1234', 'hex'), delayMs: delayedBeyondTimeoutMs },
     ])
 
     beforeEach(function () {
@@ -36,13 +102,13 @@ describe('ipfs', function () {
     })
 
     it('returns buffer contents', async function () {
-      const ipfs = new Ipfs(ipfsOrigin, ipfsTimeoutMs)
+      const ipfs = new Ipfs(mockIpfsOrigin, ipfsTimeoutMs)
       const result = await ipfs.getFile('okCid')
       expect(result.toString('hex')).to.equal('1234')
     })
 
     it('throws when request fails', async function () {
-      const ipfs = new Ipfs(ipfsOrigin, ipfsTimeoutMs)
+      const ipfs = new Ipfs(mockIpfsOrigin, ipfsTimeoutMs)
       const error = await ipfs.getFile('badCid').then(
         () => {
           throw new Error('Expected an error')
@@ -55,31 +121,27 @@ describe('ipfs', function () {
 
     it('throws timeout when request exceeds timeout', async function () {
       clock = useFakeTimers({ toFake: ['setTimeout'] })
+      await withDelayedIpfsMock('/api/v0/cat?arg=timeoutCid', Buffer.from('1234', 'hex'), delayedBeyondTimeoutMs, async () => {
+        const ipfs = new Ipfs(ipfsOrigin, shortTimeoutMs)
+        const errorPromise = ipfs.getFile('timeoutCid').then(
+          () => {
+            throw new Error('Expected an error')
+          },
+          (caughtError: unknown) => caughtError as Error
+        )
 
-      const ipfs = new Ipfs(ipfsOrigin, shortTimeoutMs)
-      const errorPromise = ipfs.getFile('timeoutCid').then(
-        () => {
-          throw new Error('Expected an error')
-        },
-        (caughtError: unknown) => caughtError as Error
-      )
+        await clock?.tickAsync(shortTimeoutMs)
+        const error = await errorPromise
 
-      await clock.tickAsync(shortTimeoutMs)
-      const error = await errorPromise
-
-      expect(error.message).to.equal('Timeout fetching file timeoutCid from IPFS')
+        expect(error.message).to.equal('Timeout fetching file timeoutCid from IPFS')
+      })
     })
   })
 
   describe('uploadFile', function () {
     const uploadBuffer = Buffer.from('hello', 'utf8')
     let clock: SinonFakeTimers | undefined
-    const { ipfsOrigin } = withIpfsAddResponse([
-      { cid: 'testCid', code: 200 },
-      { cid: 'ignoredFor400', code: 400, body: '{}' },
-      { cid: 'ignoredInvalid', code: 200, body: '{"Hash":null}' },
-      { cid: 'ignoredTimeout', code: 200, body: '{"Hash":"late"}', delayMs: delayedBeyondTimeoutMs },
-    ])
+    const { ipfsOrigin: mockIpfsOrigin } = withIpfsAddResponse([{ cid: 'testCid', code: 200, body: uploadBuffer }])
 
     beforeEach(function () {
       clock = undefined
@@ -90,51 +152,56 @@ describe('ipfs', function () {
     })
 
     it('returns uploaded CID on success', async function () {
-      const ipfs = new Ipfs(ipfsOrigin, ipfsTimeoutMs)
+      const ipfs = new Ipfs(mockIpfsOrigin, ipfsTimeoutMs)
       const result = await ipfs.uploadFile(uploadBuffer)
       expect(result).to.equal('testCid')
     })
 
     it('throws when request fails (code 400)', async function () {
-      const ipfs = new Ipfs(ipfsOrigin, ipfsTimeoutMs)
-      const error = await ipfs.uploadFile(uploadBuffer).then(
-        () => {
-          throw new Error('Expected an error')
-        },
-        (caughtError: unknown) => caughtError as Error
-      )
+      await withIpfsAddStatusMock(400, '{}', async () => {
+        const ipfs = new Ipfs(ipfsOrigin, ipfsTimeoutMs)
+        const error = await ipfs.uploadFile(uploadBuffer).then(
+          () => {
+            throw new Error('Expected an error')
+          },
+          (caughtError: unknown) => caughtError as Error
+        )
 
-      expect(error.message).to.equal(`Error calling IPFS`)
+        expect(error.message).to.equal(`Error calling IPFS`)
+      })
     })
 
     it('throws when response payload is invalid', async function () {
-      const ipfs = new Ipfs(ipfsOrigin, ipfsTimeoutMs)
-      const error = await ipfs.uploadFile(uploadBuffer).then(
-        () => {
-          throw new Error('Expected an error')
-        },
-        (caughtError: unknown) => caughtError as Error
-      )
+      await withIpfsAddStatusMock(200, '{"Hash":null}', async () => {
+        const ipfs = new Ipfs(ipfsOrigin, ipfsTimeoutMs)
+        const error = await ipfs.uploadFile(uploadBuffer).then(
+          () => {
+            throw new Error('Expected an error')
+          },
+          (caughtError: unknown) => caughtError as Error
+        )
 
-      expect(error.message).to.contain(`Error calling IPFS`)
+        expect(error.message).to.contain(`Error calling IPFS`)
+      })
     })
 
     it('throws timeout when upload exceeds timeout', async function () {
       clock = useFakeTimers({ toFake: ['setTimeout'] })
+      await withDelayedIpfsMock('/api/v0/add?cid-version=1', '{"Hash":"late"}', delayedBeyondTimeoutMs, async () => {
+        const ipfs = new Ipfs(ipfsOrigin, shortTimeoutMs)
+        const errorPromise = ipfs.uploadFile(uploadBuffer).then(
+          () => {
+            throw new Error('Expected an error')
+          },
+          (caughtError: unknown) => caughtError as Error
+        )
 
-      const ipfs = new Ipfs(ipfsOrigin, shortTimeoutMs)
-      const errorPromise = ipfs.uploadFile(uploadBuffer).then(
-        () => {
-          throw new Error('Expected an error')
-        },
-        (caughtError: unknown) => caughtError as Error
-      )
+        await clock?.tickAsync(shortTimeoutMs)
+        const error = await errorPromise
 
-      await clock.tickAsync(shortTimeoutMs)
-      const error = await errorPromise
-
-      expect(error).instanceOf(Error)
-      expect(error.message).to.equal('Timeout uploading file to IPFS')
+        expect(error).instanceOf(Error)
+        expect(error.message).to.equal('Timeout uploading file to IPFS')
+      })
     })
   })
 })

--- a/src/ipfs/__tests__/index.test.ts
+++ b/src/ipfs/__tests__/index.test.ts
@@ -28,8 +28,8 @@ const withDelayedIpfsMock = async (
     method: 'POST',
     ...(route === '/api/v0/add?cid-version=1'
       ? {
-          body: (calledBody: string) => {
-            const asBuf = calledBody as unknown as FormData
+          body: (calledBody: unknown) => {
+            const asBuf = calledBody as FormData
             const asArr = [...asBuf.entries()]
             return asArr.length === 1 && asArr[0][0] === 'file'
           },
@@ -59,8 +59,8 @@ const withIpfsAddStatusMock = async (statusCode: number, body: string, run: () =
     .intercept({
       path: '/api/v0/add?cid-version=1',
       method: 'POST',
-      body: (calledBody: string) => {
-        const asBuf = calledBody as unknown as FormData
+      body: (calledBody: unknown) => {
+        const asBuf = calledBody as FormData
         const asArr = [...asBuf.entries()]
         return asArr.length === 1 && asArr[0][0] === 'file'
       },

--- a/src/ipfs/index.ts
+++ b/src/ipfs/index.ts
@@ -1,3 +1,4 @@
+import { fetch, FormData } from 'undici'
 import { addResponseParser } from './responseParser.js'
 
 export interface MetadataFile {


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Chore

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or Github Issue, please provide the ticket URL here. -->

## High level description

Update to Undici 8

## Detailed description

Use Undici `fetch` in IPFS
Modified IPFS tests to:
* add network isolation
* use Undici dispatcher-based local helpers
* replace Sinon global fetch stubbing and restore usage - timeouts and invalid tests now use Undici mocks/interceptors

## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

Bump to Undici 8

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
